### PR TITLE
FIX: timeout and RT calculation in wait_for_button_press

### DIFF
--- a/scansync/meg.py
+++ b/scansync/meg.py
@@ -241,12 +241,14 @@ class MEGTriggerBox:
                 
                 # Check whether a timeout occurred.
                 if timeout is not None:
-                    timed_out = t1 - t0 < timeout
+                    timed_out = t1 - t0 > timeout
             
             # Stop the task.
             task.stop()
-                
-        return button, t1
+        
+        RT = t1 - t0
+
+        return button, RT
     
     
     def _wait_for_button_up(self, buttons=None):


### PR DESCRIPTION
1. Original `timed_out = t1 - t0 < timeout` always returns True immediately if `timeout` is > 0. Changing the sign of the inequality to `>` only returns True when time elapsed (i.e., `t1 - t0`) is greater than the desired period (i.e., `timeout`)
2. Function original returns `t1`, which is less informative than reaction time, which is `t1 - t0`. 